### PR TITLE
Use initWithCoder: instead of awakeFromNib

### DIFF
--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -79,10 +79,15 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
     return self;
 }
 
-- (void)awakeFromNib
+- (id)initWithCoder:(NSCoder *)aDecoder
 {
-	[super awakeFromNib];
-	[self _initialize];
+    self = [super initWithCoder:aDecoder];
+    if (nil == self) {
+        return nil;
+    }
+
+    [self _initialize];
+    return self;
 }
 
 - (void)dealloc


### PR DESCRIPTION
When configuring an `SMPageControl` from inside a Storyboard or XIB file, the developer might want to use _User Defined Runtime Attributes_ to configure the instance. `awakeFromNib` is called after those attributes are evaluated by the nib loading system, effectively overwriting the attributes defined in the Storyboard or XIB file. Therefore, `initWithCoder:` is the more appropriate location to perform the initialization.

![Screen Shot 2013-02-08 at 10 55 23](https://f.cloud.github.com/assets/161041/139045/aaa24214-71d9-11e2-98ca-52d39b9c7763.png)
