### PR TITLE
Fix IBOutlet warnings. Remove unused property.

### DIFF
--- a/Example/SMPageControl/SMViewController.h
+++ b/Example/SMPageControl/SMViewController.h
@@ -11,15 +11,15 @@
 
 @interface SMViewController : UIViewController
 
-@property (nonatomic, readonly) IBOutlet UIScrollView *scrollview;
-@property (nonatomic, readonly) IBOutlet UIPageControl *pageControl;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl1;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl2;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl3;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl4;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl5;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl6;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl7;
-@property (nonatomic, readonly) IBOutlet SMPageControl *spacePageControl8;
+@property (nonatomic, weak) IBOutlet UIScrollView *scrollview;
+@property (nonatomic, weak) IBOutlet UIPageControl *pageControl;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl1;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl2;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl3;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl4;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl5;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl6;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl7;
+@property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl8;
 
 @end

--- a/Example/SMPageControl/SMViewController.h
+++ b/Example/SMPageControl/SMViewController.h
@@ -11,7 +11,6 @@
 
 @interface SMViewController : UIViewController
 
-@property (nonatomic, weak) IBOutlet UIScrollView *scrollview;
 @property (nonatomic, weak) IBOutlet UIPageControl *pageControl;
 @property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl1;
 @property (nonatomic, weak) IBOutlet SMPageControl *spacePageControl2;


### PR DESCRIPTION
This fixes the warning "readonly IBOutlet property when auto-synthesized may not work correctly with 'nib' loader".

Also, weak is better than assign when using weak references to objects, because weak prevents dangling pointers.
