### PR TITLE
Improved updatePageNumberForScrollView: when reversing

### DIFF
--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -342,7 +342,14 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 
 - (void)updatePageNumberForScrollView:(UIScrollView *)scrollView
 {
-	NSInteger page = (int)floorf(scrollView.contentOffset.x / scrollView.bounds.size.width);
+	// Use the trailing edge on reverse and leading edge on forward
+	NSInteger page;
+	if (self.currentPage * scrollView.bounds.size.width > scrollView.contentOffset.x) {
+		page = (int)ceilf(scrollView.contentOffset.x / scrollView.bounds.size.width);
+	} else {
+		page = (int)floorf(scrollView.contentOffset.x / scrollView.bounds.size.width);
+	}
+    
 	self.currentPage = page;
 }
 


### PR DESCRIPTION
When using the UIScrollView for updating the page control's current page
use the trailing edge on reverse instead of the leading edge.  This 
removes funny edge affects on bounces and makes the forward & backward 
scrolling experiences the same.
