### PR TITLE
New Feature: Advanced Tap (Tap to select indivisual Indicator)

### DIFF
--- a/Example/SMPageControl/SMViewController.m
+++ b/Example/SMPageControl/SMViewController.m
@@ -28,6 +28,8 @@
 	self.spacePageControl7.numberOfPages = 10;
 	self.spacePageControl8.numberOfPages = 10;
 	
+    self.spacePageControl5.useAdvancedTap = YES;
+    
 	self.spacePageControl2.indicatorMargin = 20.0f;
 	self.spacePageControl2.indicatorDiameter = 10.0f;
 	

--- a/Example/SMPageControl/en.lproj/SMViewController_iPad.xib
+++ b/Example/SMPageControl/en.lproj/SMViewController_iPad.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
-		<int key="IBDocument.SystemTarget">1536</int>
-		<string key="IBDocument.SystemVersion">12C60</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2840</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1926</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>IBProxyObject</string>
@@ -42,7 +42,6 @@
 						<object class="NSPSMatrix" key="NSFrameMatrix"/>
 						<string key="NSFrame">{{352, 29}, {320, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="707133627"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -60,7 +59,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 203}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1038875333"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -77,7 +75,6 @@
 						<int key="NSvFlags">293</int>
 						<string key="NSFrame">{{372, 12}, {280, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="1061275447"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -114,7 +111,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{372, 127}, {280, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="190473815"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -141,7 +137,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 170}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="957582254"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -175,7 +170,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 356}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="848894460"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -202,7 +196,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 495}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="406492332"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -210,7 +203,7 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">use images as page indicators</string>
+						<string key="IBUIText">use images as page indicators and advanceTap</string>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MC41Nzk0NjUxMDA0AA</bytes>
@@ -229,7 +222,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 592}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="983784327"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -256,7 +248,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 396}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="702559608"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -271,7 +262,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 436}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="976635559"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -286,7 +276,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 534}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="689592712"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -301,7 +290,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 685}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="80309604"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -328,7 +316,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 726}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -343,7 +330,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 627}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="400545319"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -358,7 +344,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 263}, {300, 22}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="673266801"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -385,7 +370,6 @@
 						<int key="NSvFlags">301</int>
 						<string key="NSFrame">{{362, 296}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="300443276"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -401,7 +385,6 @@
 						<array class="NSMutableArray" key="NSSubviews"/>
 						<string key="NSFrame">{{0, 70}, {1024, 1}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="378842605"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -415,7 +398,6 @@
 						<int key="NSvFlags">295</int>
 						<string key="NSFrame">{{0, 71}, {1024, 1}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="178185085"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
@@ -428,7 +410,6 @@
 				</array>
 				<string key="NSFrame">{{0, 20}, {1024, 768}}</string>
 				<reference key="NSSuperview"/>
-				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="1000558957"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">3</int>
@@ -693,79 +674,11 @@
 			<nil key="sourceID"/>
 			<int key="maxID">148</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes">
-			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
-				<object class="IBPartialClassDescription">
-					<string key="className">SMPageControl</string>
-					<string key="superclassName">UIControl</string>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SMPageControl.h</string>
-					</object>
-				</object>
-				<object class="IBPartialClassDescription">
-					<string key="className">SMViewController</string>
-					<string key="superclassName">UIViewController</string>
-					<dictionary class="NSMutableDictionary" key="outlets">
-						<string key="pageControl">UIPageControl</string>
-						<string key="scrollview">UIScrollView</string>
-						<string key="spacePageControl1">SMPageControl</string>
-						<string key="spacePageControl2">SMPageControl</string>
-						<string key="spacePageControl3">SMPageControl</string>
-						<string key="spacePageControl4">SMPageControl</string>
-						<string key="spacePageControl5">SMPageControl</string>
-						<string key="spacePageControl6">SMPageControl</string>
-						<string key="spacePageControl7">SMPageControl</string>
-					</dictionary>
-					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
-						<object class="IBToOneOutletInfo" key="pageControl">
-							<string key="name">pageControl</string>
-							<string key="candidateClassName">UIPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="scrollview">
-							<string key="name">scrollview</string>
-							<string key="candidateClassName">UIScrollView</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl1">
-							<string key="name">spacePageControl1</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl2">
-							<string key="name">spacePageControl2</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl3">
-							<string key="name">spacePageControl3</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl4">
-							<string key="name">spacePageControl4</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl5">
-							<string key="name">spacePageControl5</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl6">
-							<string key="name">spacePageControl6</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="spacePageControl7">
-							<string key="name">spacePageControl7</string>
-							<string key="candidateClassName">SMPageControl</string>
-						</object>
-					</dictionary>
-					<object class="IBClassDescriptionSource" key="sourceIdentifier">
-						<string key="majorKey">IBProjectSource</string>
-						<string key="minorKey">./Classes/SMViewController.h</string>
-					</object>
-				</object>
-			</array>
-		</object>
+		<object class="IBClassDescriber" key="IBDocument.Classes"/>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1926</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/Example/SMPageControl/en.lproj/SMViewController_iPhone.xib
+++ b/Example/SMPageControl/en.lproj/SMViewController_iPhone.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
-		<int key="IBDocument.SystemTarget">1536</int>
-		<string key="IBDocument.SystemVersion">12C3006</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2844</string>
-		<string key="IBDocument.AppKitVersion">1187.34</string>
-		<string key="IBDocument.HIToolboxVersion">625.00</string>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">12E55</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
+		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1930</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<array key="IBDocument.IntegratedClassDependencies">
 			<string>IBProxyObject</string>
@@ -210,7 +210,7 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<string key="IBUIText">use images as page indicators</string>
+						<string key="IBUIText">use images as page indicators and advanceTap</string>
 						<object class="NSColor" key="IBUITextColor">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MC41Nzk0NjUxMDA0AA</bytes>
@@ -370,6 +370,7 @@
 						<string key="NSFrame">{{10, 458}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="400545319"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">3</int>
@@ -384,7 +385,7 @@
 						<string key="NSFrame">{{10, 401}, {300, 36}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="400545319"/>
+						<reference key="NSNextKeyView" ref="404631290"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">3</int>
@@ -784,7 +785,6 @@
 					<string key="superclassName">UIViewController</string>
 					<dictionary class="NSMutableDictionary" key="outlets">
 						<string key="pageControl">UIPageControl</string>
-						<string key="scrollview">UIScrollView</string>
 						<string key="spacePageControl1">SMPageControl</string>
 						<string key="spacePageControl2">SMPageControl</string>
 						<string key="spacePageControl3">SMPageControl</string>
@@ -798,10 +798,6 @@
 						<object class="IBToOneOutletInfo" key="pageControl">
 							<string key="name">pageControl</string>
 							<string key="candidateClassName">UIPageControl</string>
-						</object>
-						<object class="IBToOneOutletInfo" key="scrollview">
-							<string key="name">scrollview</string>
-							<string key="candidateClassName">UIScrollView</string>
 						</object>
 						<object class="IBToOneOutletInfo" key="spacePageControl1">
 							<string key="name">spacePageControl1</string>
@@ -847,6 +843,6 @@
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>
 		<int key="IBDocument.defaultPropertyAccessControl">3</int>
-		<string key="IBCocoaTouchPluginVersion">1930</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/SMPageControl.h
+++ b/SMPageControl.h
@@ -22,6 +22,8 @@ typedef NS_ENUM(NSUInteger, SMPageControlVerticalAlignment) {
 
 @interface SMPageControl : UIControl
 
+@property (nonatomic) BOOL useAdvancedTap;
+
 @property (nonatomic) NSInteger numberOfPages;
 @property (nonatomic) NSInteger currentPage;
 @property (nonatomic) CGFloat indicatorMargin							UI_APPEARANCE_SELECTOR; // deafult is 10

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -237,17 +237,8 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
     CGSize size = [self sizeForNumberOfPages:self.numberOfPages];
     CGRect rect = CGRectMake(0, 0, size.width, size.height);
     rect.size.height = self.frame.size.height;
-    switch (self.alignment) {
-        case SMPageControlAlignmentCenter:
-            rect.origin.x = (self.frame.size.width-rect.size.width)/2.0;
-            break;
-        case SMPageControlAlignmentRight:
-            rect.origin.x = self.frame.size.width-rect.size.width;
-            break;
-        case SMPageControlAlignmentLeft: // DO NOTHING
-        default:
-            break;
-    }
+    rect.origin.x = [self _leftOffset];
+
     if (CGRectContainsPoint(rect, point)) {
         float segment = rect.size.width/self.numberOfPages;
         int index = (point.x - rect.origin.x)/segment;

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -233,6 +233,34 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 	return rect;
 }
 
+-(NSInteger) _indexOfIndicatorAtPoint:(CGPoint) point {
+    CGSize size = [self sizeForNumberOfPages:self.numberOfPages];
+    CGRect rect = CGRectMake(0, 0, size.width, size.height);
+    rect.size.height = self.frame.size.height;
+    switch (self.alignment) {
+        case SMPageControlAlignmentCenter:
+            rect.origin.x = (self.frame.size.width-rect.size.width)/2.0;
+            break;
+        case SMPageControlAlignmentRight:
+            rect.origin.x = self.frame.size.width-rect.size.width;
+            break;
+        case SMPageControlAlignmentLeft: // DO NOTHING
+        default:
+            break;
+    }
+    if (CGRectContainsPoint(rect, point)) {
+        float segment = rect.size.width/self.numberOfPages;
+        int index = (point.x - rect.origin.x)/segment;
+        return index;
+    } else if(point.x < rect.origin.x){
+        return MAX(0, self.currentPage-1);
+    } else if (point.x > rect.origin.x){
+        return MIN(self.numberOfPages-1, self.currentPage+1);
+    }
+    // should not be here
+    return 0;
+}
+
 - (void)_setImage:(UIImage *)image forPage:(NSInteger)pageIndex type:(SMPageControlImageType)type
 {
 	if (pageIndex < 0 || pageIndex >= _numberOfPages) {
@@ -412,14 +440,20 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 {
 	UITouch *touch = [touches anyObject];
 	CGPoint point = [touch locationInView:self];
-	CGSize size = [self sizeForNumberOfPages:self.numberOfPages];
-	CGFloat left = [self _leftOffset];
-	CGFloat middle = left + (size.width / 2.0f);
-	if (point.x < middle) {
-		[self setCurrentPage:self.currentPage - 1 sendEvent:YES canDefer:YES];
-	} else {
-		[self setCurrentPage:self.currentPage + 1 sendEvent:YES canDefer:YES];
-	}
+    if (self.useAdvancedTap) {
+        [self setCurrentPage:[self _indexOfIndicatorAtPoint:point]
+                   sendEvent:YES
+                    canDefer:YES];
+    } else {
+        CGSize size = [self sizeForNumberOfPages:self.numberOfPages];
+        CGFloat left = [self _leftOffset];
+        CGFloat middle = left + (size.width / 2.0f);
+        if (point.x < middle) {
+            [self setCurrentPage:self.currentPage - 1 sendEvent:YES canDefer:YES];
+        } else {
+            [self setCurrentPage:self.currentPage + 1 sendEvent:YES canDefer:YES];
+        }
+    }
 }
 
 #pragma mark - Accessors

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ SMPageControl has a variety of simple (yet powerful) areas of customization, and
 * Indicator Alignment
 * Images as Indicators
 * Image Masks as Indicators
+* Advanced Tap Option
 * Per-Indicator customization
 * Extensive Support for UIAppearance
 * Extended Support for UIAccessibility
@@ -30,6 +31,16 @@ pageControl.pageIndicatorImage = [UIImage imageNamed:@"pageDot"];
 pageControl.currentPageIndicatorImage = [UIImage imageNamed:@"currentPageDot"];
 [pageControl sizeToFit];
 [self.view addSubview:pageControl];
+
+```
+
+## Advanced Tap (Tap to select indivisual Indicator)
+
+As with SMPageControl you can use bigger indicator and more spacing between them, one may want to jump to specific indocator by just tapping on it, insetad of default UIPageControl-type left/right side tap-tap-tap style. So if you want that, you have it. Just make useAdvancedTap to YES (which is by default NO).
+
+``` objective-c
+SMPageControl *pageControl = /* Initialization and other configs */
+pageControl.useAdvancedTap = YES;
 
 ```
 


### PR DESCRIPTION
## Advanced Tap (Tap to select indivisual Indicator)

As with SMPageControl you can use bigger indicator and more spacing between them, one may want to jump to specific indocator by just tapping on it, insetad of default UIPageControl-type left/right side tap-tap-tap style. So if you want that, you have it. Just make useAdvancedTap to YES (which is by default NO).

``` objective-c
SMPageControl *pageControl = /* Initialization and other configs */
pageControl.useAdvancedTap = YES;

```
