### PR TITLE
Overrides sizeThatFits:  instead of sizeToFit

### DIFF
--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -367,13 +367,11 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	return [self _imageForPage:pageIndex type:SMPageControlImageTypeMask];
 }
 
-- (void)sizeToFit
+- (CGSize)sizeThatFits:(CGSize)size
 {
-	CGRect frame = self.frame;
-	CGSize size = [self sizeForNumberOfPages:self.numberOfPages];
-	size.height = MAX(size.height, MIN_HEIGHT);
-	frame.size = size;
-	self.frame = frame;
+    CGSize sizeThatFits = [self sizeForNumberOfPages:self.numberOfPages];
+	sizeThatFits.height = MAX(sizeThatFits.height, MIN_HEIGHT);
+    return sizeThatFits;
 }
 
 - (void)updatePageNumberForScrollView:(UIScrollView *)scrollView


### PR DESCRIPTION
Documentation says "You should not override this method. If you want to change the default sizing information for your view, override the sizeThatFits: instead. That method performs any needed calculations and returns them to this method, which then makes the change."
