### PR TITLE
During scrolling, update page number at half-way point between pages.

### DIFF
--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -422,7 +422,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 {
 	size_t pixelsWide = image.size.width * image.scale;
 	size_t pixelsHigh = image.size.height * image.scale;
-	int bitmapBytesPerRow = (pixelsWide * 1);
+	size_t bitmapBytesPerRow = (pixelsWide * 1);
 	CGContextRef context = CGBitmapContextCreate(NULL, pixelsWide, pixelsHigh, CGImageGetBitsPerComponent(image.CGImage), bitmapBytesPerRow, NULL, (CGBitmapInfo)kCGImageAlphaOnly);
 	CGContextTranslateCTM(context, 0.f, pixelsHigh);
 	CGContextScaleCTM(context, 1.0f, -1.0f);

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -93,7 +93,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	_verticalAlignment = SMPageControlVerticalAlignmentMiddle;
 	
 	self.isAccessibilityElement = YES;
-	self.accessibilityTraits = UIAccessibilityTraitUpdatesFrequently;
+	self.accessibilityTraits = UIAccessibilityTraitUpdatesFrequently | UIAccessibilityTraitAdjustable;
 	self.accessibilityPageControl = [[UIPageControl alloc] init];
 }
 
@@ -679,6 +679,18 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	} else {
 		self.accessibilityValue = accessibilityValue;
 	}
+}
+
+#pragma mark - UIAccessibilityAction
+
+- (void)accessibilityIncrement
+{
+	[self setCurrentPage:self.currentPage + 1 sendEvent:YES canDefer:NO];
+}
+
+- (void)accessibilityDecrement
+{
+	[self setCurrentPage:self.currentPage - 1 sendEvent:YES canDefer:NO];
 }
 
 @end

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -95,6 +95,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	self.isAccessibilityElement = YES;
 	self.accessibilityTraits = UIAccessibilityTraitUpdatesFrequently;
 	self.accessibilityPageControl = [[UIPageControl alloc] init];
+	self.contentMode = UIViewContentModeRedraw;
 }
 
 - (id)initWithFrame:(CGRect)frame

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -150,7 +150,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	CGImageRef maskingImage = nil;
 	CGSize maskSize = CGSizeZero;
 	
-	for (NSUInteger i = 0; i < _numberOfPages; i++) {
+	for (NSInteger i = 0; i < _numberOfPages; i++) {
 		NSNumber *indexNumber = @(i);
 		
 		if (i == _displayedPage) {
@@ -298,7 +298,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
     }
 }
 
-- (void)setImage:(UIImage *)image forPage:(NSInteger)pageIndex;
+- (void)setImage:(UIImage *)image forPage:(NSInteger)pageIndex
 {
     [self _setImage:image forPage:pageIndex type:SMPageControlImageTypeNormal];
 	[self _updateMeasuredIndicatorSizes];

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -376,7 +376,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 
 - (void)updatePageNumberForScrollView:(UIScrollView *)scrollView
 {
-	NSInteger page = (int)floorf(scrollView.contentOffset.x / scrollView.bounds.size.width);
+	NSInteger page = (NSInteger)roundf(scrollView.contentOffset.x / scrollView.bounds.size.width);
 	self.currentPage = page;
 }
 

--- a/SMPageControl.podspec
+++ b/SMPageControl.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "SMPageControl"
-  s.version      = "1.1"
+  s.version      = "1.2"
   s.summary      = "UIPageControl’s fancy one-upping cousin."
   s.description  = <<-DESC
     Designers love to make beautifully custom page controls that fit in with all the wood,
@@ -35,7 +35,7 @@ Pod::Spec.new do |s|
   s.author       = { "Jerry Jones" => "jerry@spacemanlabs.com" }
   s.source       = {
     :git => "https://github.com/Spaceman-Labs/SMPageControl.git",
-    :tag => "1.1"
+    :tag => "1.2"
   }
   s.platform     = :ios, '5.0'
   s.source_files = 'SMPageControl.{h,m}'


### PR DESCRIPTION
This is an alternative to [Club15CC’s pull request](https://github.com/Spaceman-Labs/SMPageControl/pull/9). The page indicator is updated symmetrically for left and right scrolling, but at the mid-point between two pages rather than at the end of scrolling. It is debatable which is the superior user experience. 
