### PR TITLE
Redraw on bounds change to avoid stretching the indicators

### DIFF
--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -95,6 +95,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	self.isAccessibilityElement = YES;
 	self.accessibilityTraits = UIAccessibilityTraitUpdatesFrequently;
 	self.accessibilityPageControl = [[UIPageControl alloc] init];
+	self.contentMode = UIViewContentModeRedraw;
 }
 
 - (id)initWithFrame:(CGRect)frame


### PR DESCRIPTION
If the bounds of the `SMPageControl` change, the indicators are currently not redrawn which leads to stretched graphics.

Given the following page control in portrait orientation that fills the width of the screen
![smpagecontrol_portrait](https://f.cloud.github.com/assets/507058/1343990/b1ca20c8-367a-11e3-9e3d-94bf0d73c985.png)

rotating to landscape orientation where the control still fills the width of the screen stretches the dots.
![smpagecontrol_landscape](https://f.cloud.github.com/assets/507058/1344000/db5e64e4-367a-11e3-9a3f-157f80b8727c.png)

After the change in this pull request, the dots are properly redrawn automatically whenever the bounds of the `SMPageControl` change.
![smpagecontrol_landscape2](https://f.cloud.github.com/assets/507058/1344005/e3374a96-367a-11e3-9a88-188ace156d79.png)
