### PR TITLE
Added support for AutoLayout matching UIPageControl

### DIFF
--- a/SMPageControl.h
+++ b/SMPageControl.h
@@ -31,6 +31,7 @@ typedef NS_ENUM(NSUInteger, SMPageControlTapBehavior) {
 @property (nonatomic) NSInteger currentPage;
 @property (nonatomic) CGFloat indicatorMargin							UI_APPEARANCE_SELECTOR; // deafult is 10
 @property (nonatomic) CGFloat indicatorDiameter							UI_APPEARANCE_SELECTOR; // deafult is 6
+@property (nonatomic) CGFloat minHeight									UI_APPEARANCE_SELECTOR; // default is 36, cannot be less than indicatorDiameter
 @property (nonatomic) SMPageControlAlignment alignment					UI_APPEARANCE_SELECTOR; // deafult is Center
 @property (nonatomic) SMPageControlVerticalAlignment verticalAlignment	UI_APPEARANCE_SELECTOR;	// deafult is Middle
 

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -522,14 +522,14 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	if (indicatorDiameter == _indicatorDiameter) {
 		return;
 	}
+	
+	_indicatorDiameter = indicatorDiameter;
 
 	// Absolute minimum height of the control is the indicator diameter
 	if (_minHeight < indicatorDiameter) {
-		_minHeight = indicatorDiameter;
-		[self setNeedsLayout];
+		self.minHeight = indicatorDiameter;
 	}
-	
-	_indicatorDiameter = indicatorDiameter;
+
 	[self _updateMeasuredIndicatorSizes];
 	[self setNeedsDisplay];
 }
@@ -556,6 +556,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	}
 
 	_minHeight = minHeight;
+	if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
+		[self invalidateIntrinsicContentSize];
+	}
 	[self setNeedsLayout];
 }
 

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -19,8 +19,6 @@
 #define DEFAULT_INDICATOR_WIDTH_LARGE 7.0f
 #define DEFAULT_INDICATOR_MARGIN_LARGE 9.0f
 
-#define MIN_HEIGHT 36.0f
-
 typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 	SMPageControlImageTypeNormal = 1,
 	SMPageControlImageTypeCurrent,
@@ -78,6 +76,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 {
 	_numberOfPages = 0;
 	_tapBehavior = SMPageControlTapBehaviorStep;
+	_minHeight = 36.0f;
     
 	self.backgroundColor = [UIColor clearColor];
 	
@@ -370,13 +369,13 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 - (CGSize)sizeThatFits:(CGSize)size
 {
 	CGSize sizeThatFits = [self sizeForNumberOfPages:self.numberOfPages];
-	sizeThatFits.height = MAX(sizeThatFits.height, MIN_HEIGHT);
+	sizeThatFits.height = MAX(sizeThatFits.height, _minHeight);
 	return sizeThatFits;
 }
 
 - (CGSize)intrinsicContentSize
 {
-	CGSize intrinsicContentSize = CGSizeMake(UIViewNoIntrinsicMetric, MAX(_measuredIndicatorHeight, MIN_HEIGHT));
+	CGSize intrinsicContentSize = CGSizeMake(UIViewNoIntrinsicMetric, MAX(_measuredIndicatorHeight, _minHeight));
 	return intrinsicContentSize;
 }
 
@@ -529,6 +528,21 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	
 	_indicatorMargin = indicatorMargin;
 	[self setNeedsDisplay];
+}
+
+- (void)setMinHeight:(CGFloat)minHeight
+{
+	if (minHeight == _minHeight) {
+		return;
+	}
+
+   // Absolute minimum height of the control is the indicator diameter
+	if (minHeight < _indicatorDiameter) {
+		minHeight = _indicatorDiameter;
+	}
+
+	_minHeight = minHeight;
+	[self setNeedsLayout];
 }
 
 - (void)setNumberOfPages:(NSInteger)numberOfPages

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -520,6 +520,12 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	if (indicatorDiameter == _indicatorDiameter) {
 		return;
 	}
+
+	// Absolute minimum height of the control is the indicator diameter
+	if (_minHeight < indicatorDiameter) {
+		_minHeight = indicatorDiameter;
+		[self setNeedsLayout];
+	}
 	
 	_indicatorDiameter = indicatorDiameter;
 	[self _updateMeasuredIndicatorSizes];

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -376,6 +376,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 
 - (CGSize)intrinsicContentSize
 {
+	if (_numberOfPages < 1 || (_numberOfPages < 2 && _hidesForSinglePage)) {
+		return CGSizeMake(UIViewNoIntrinsicMetric, 0.0f);
+	}
 	CGSize intrinsicContentSize = CGSizeMake(UIViewNoIntrinsicMetric, MAX(_measuredIndicatorHeight, _minHeight));
 	return intrinsicContentSize;
 }
@@ -557,6 +560,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	self.accessibilityPageControl.numberOfPages = numberOfPages;
 	
 	_numberOfPages = MAX(0, numberOfPages);
+	[self invalidateIntrinsicContentSize];
 	[self updateAccessibilityValue];
 	[self setNeedsDisplay];
 }

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -15,9 +15,11 @@
 
 #define DEFAULT_INDICATOR_WIDTH 6.0f
 #define DEFAULT_INDICATOR_MARGIN 10.0f
+#define DEFAULT_MIN_HEIGHT 36.0f
 
 #define DEFAULT_INDICATOR_WIDTH_LARGE 7.0f
 #define DEFAULT_INDICATOR_MARGIN_LARGE 9.0f
+#define DEFAULT_MIN_HEIGHT_LARGE 36.0f
 
 typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 	SMPageControlImageTypeNormal = 1,
@@ -76,7 +78,6 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 {
 	_numberOfPages = 0;
 	_tapBehavior = SMPageControlTapBehaviorStep;
-	_minHeight = 36.0f;
     
 	self.backgroundColor = [UIColor clearColor];
 	
@@ -399,12 +400,14 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 			self.indicatorDiameter = DEFAULT_INDICATOR_WIDTH_LARGE;
 			self.indicatorMargin = DEFAULT_INDICATOR_MARGIN_LARGE;
 			self.pageIndicatorTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.2f];
+			self.minHeight = DEFAULT_MIN_HEIGHT_LARGE;
 			break;
 		case SMPageControlDefaultStyleClassic:
 		default:
 			self.indicatorDiameter = DEFAULT_INDICATOR_WIDTH;
 			self.indicatorMargin = DEFAULT_INDICATOR_MARGIN;
 			self.pageIndicatorTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.3f];
+			self.minHeight = DEFAULT_MIN_HEIGHT;
 			break;
 	}
 }

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -463,7 +463,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 		[self _updateMeasuredIndicatorSizeWithSize:self.pageIndicatorMaskImage.size];
 	}
 
-	[self invalidateIntrinsicContentSize];
+	if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
+		[self invalidateIntrinsicContentSize];
+	}
 }
 
 
@@ -566,7 +568,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	self.accessibilityPageControl.numberOfPages = numberOfPages;
 	
 	_numberOfPages = MAX(0, numberOfPages);
-	[self invalidateIntrinsicContentSize];
+	if ([self respondsToSelector:@selector(invalidateIntrinsicContentSize)]) {
+		[self invalidateIntrinsicContentSize];
+	}
 	[self updateAccessibilityValue];
 	[self setNeedsDisplay];
 }

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -369,9 +369,15 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 
 - (CGSize)sizeThatFits:(CGSize)size
 {
-    CGSize sizeThatFits = [self sizeForNumberOfPages:self.numberOfPages];
+	CGSize sizeThatFits = [self sizeForNumberOfPages:self.numberOfPages];
 	sizeThatFits.height = MAX(sizeThatFits.height, MIN_HEIGHT);
-    return sizeThatFits;
+	return sizeThatFits;
+}
+
+- (CGSize)intrinsicContentSize
+{
+	CGSize intrinsicContentSize = CGSizeMake(UIViewNoIntrinsicMetric, MAX(_measuredIndicatorHeight, MIN_HEIGHT));
+	return intrinsicContentSize;
 }
 
 - (void)updatePageNumberForScrollView:(UIScrollView *)scrollView
@@ -451,6 +457,8 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	if (self.pageIndicatorMaskImage) {
 		[self _updateMeasuredIndicatorSizeWithSize:self.pageIndicatorMaskImage.size];
 	}
+
+	[self invalidateIntrinsicContentSize];
 }
 
 


### PR DESCRIPTION
In order to work properly in AutoLayout, `SMPageControl` needed an implementation of `intrinsicContentSize`, a straightforward adaptation of `sizeThatFits:`. Otherwise the height will be ambiguous, requiring the app to set a height constraint. However, doing so doesn't jive well with hiding the page control.

To match the behavior of `UIPageControl`, the intrinsic height is set to zero when the control should be hidden due to the number of pages (`UIPageControl` is always hidden in this way for zero pages, otherwise depends on `hidesForSinglePage`). This is convenient in the case where a constraint has been added, for example, between the top of the page control and the bottom of some other view. When the page control is hidden, the other view can adjust to fill the now vacant space.

As a minor convenience, the `MIN_HEIGHT` constant has been updated to a `minHeight` property. This allows easier customization of the control in situations where it is merely for display purposes and not receiving user interaction. In my case, the page control is being set to `userInteractionEnabled = NO` so that the minimum height can be reduced. Similarly if the page control is adjacent to another control like a tab bar, the height may be increased to enlarge the touch target.
