### PR TITLE
Small fixes for compiler warnings.

### DIFF
--- a/SMPageControl.h
+++ b/SMPageControl.h
@@ -54,7 +54,7 @@ typedef NS_ENUM(NSUInteger, SMPageControlVerticalAlignment) {
 - (void)updatePageNumberForScrollView:(UIScrollView *)scrollView;
 - (void)setScrollViewContentOffsetForCurrentPage:(UIScrollView *)scrollView animated:(BOOL)animated;
 
-#pragma UIAccessibility
+#pragma mark UIAccessibility
 
 // SMPageControl mirrors UIPageControl's standard accessibility functionality by default.
 // Basically, the accessibility label is set to "[current page index + 1] of [page count]".

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -422,7 +422,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 {
 	size_t pixelsWide = image.size.width * image.scale;
 	size_t pixelsHigh = image.size.height * image.scale;
-	int bitmapBytesPerRow = (pixelsWide * 1);
+	size_t bitmapBytesPerRow = (pixelsWide * 1);
 	CGContextRef context = CGBitmapContextCreate(NULL, pixelsWide, pixelsHigh, CGImageGetBitsPerComponent(image.CGImage), bitmapBytesPerRow, NULL, (CGBitmapInfo)kCGImageAlphaOnly);
 	CGContextTranslateCTM(context, 0.f, pixelsHigh);
 	CGContextScaleCTM(context, 1.0f, -1.0f);

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -118,7 +118,7 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
 	CGImageRef maskingImage = nil;
 	CGSize maskSize = CGSizeZero;
 	
-	for (NSUInteger i = 0; i < _numberOfPages; i++) {
+	for (NSInteger i = 0; i < _numberOfPages; i++) {
 		NSNumber *indexNumber = @(i);
 		
 		if (i == _displayedPage) {
@@ -261,7 +261,7 @@ typedef NS_ENUM(NSUInteger, SMPageControlImageType) {
     }
 }
 
-- (void)setImage:(UIImage *)image forPage:(NSInteger)pageIndex;
+- (void)setImage:(UIImage *)image forPage:(NSInteger)pageIndex
 {
     [self _setImage:image forPage:pageIndex type:SMPageControlImageTypeNormal];
 	[self _updateMeasuredIndicatorSizes];


### PR DESCRIPTION
One signedness issue, one 64-bit issue (using a 32-bit int instead of a potentially 64-bit size_t), and one trailing ';' on a method definition.
