### PR TITLE
Indicator stroke color and width options

### DIFF
--- a/SMPageControl.h
+++ b/SMPageControl.h
@@ -29,20 +29,22 @@ typedef NS_ENUM(NSUInteger, SMPageControlTapBehavior) {
 
 @property (nonatomic) NSInteger numberOfPages;
 @property (nonatomic) NSInteger currentPage;
-@property (nonatomic) CGFloat indicatorMargin							UI_APPEARANCE_SELECTOR; // deafult is 10
-@property (nonatomic) CGFloat indicatorDiameter							UI_APPEARANCE_SELECTOR; // deafult is 6
-@property (nonatomic) CGFloat minHeight									UI_APPEARANCE_SELECTOR; // default is 36, cannot be less than indicatorDiameter
-@property (nonatomic) SMPageControlAlignment alignment					UI_APPEARANCE_SELECTOR; // deafult is Center
-@property (nonatomic) SMPageControlVerticalAlignment verticalAlignment	UI_APPEARANCE_SELECTOR;	// deafult is Middle
+@property (nonatomic) CGFloat indicatorMargin								UI_APPEARANCE_SELECTOR; // deafult is 10
+@property (nonatomic) CGFloat indicatorDiameter								UI_APPEARANCE_SELECTOR; // deafult is 6
+@property (nonatomic) CGFloat minHeight										UI_APPEARANCE_SELECTOR; // default is 36, cannot be less than indicatorDiameter
+@property (nonatomic) SMPageControlAlignment alignment						UI_APPEARANCE_SELECTOR; // deafult is Center
+@property (nonatomic) SMPageControlVerticalAlignment verticalAlignment		UI_APPEARANCE_SELECTOR;	// deafult is Middle
 
-@property (nonatomic, strong) UIImage *pageIndicatorImage				UI_APPEARANCE_SELECTOR;
-@property (nonatomic, strong) UIImage *pageIndicatorMaskImage			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
-@property (nonatomic, strong) UIColor *pageIndicatorTintColor			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
+@property (nonatomic, strong) UIImage *pageIndicatorImage					UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIImage *pageIndicatorMaskImage				UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
+@property (nonatomic, strong) UIColor *pageIndicatorTintColor				UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
 @property (nonatomic, strong) UIColor *pageIndicatorTintStrokeColor			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
+@property (nonatomic, assign) CGFloat pageIndicatorTintStrokeWidth			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
 
-@property (nonatomic, strong) UIImage *currentPageIndicatorImage		UI_APPEARANCE_SELECTOR;
-@property (nonatomic, strong) UIColor *currentPageIndicatorTintColor	UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
+@property (nonatomic, strong) UIImage *currentPageIndicatorImage			UI_APPEARANCE_SELECTOR;
+@property (nonatomic, strong) UIColor *currentPageIndicatorTintColor		UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
 @property (nonatomic, strong) UIColor *currentPageIndicatorTintStrokeColor	UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
+@property (nonatomic, assign) CGFloat currentPageIndicatorTintStrokeWidth	UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
 
 @property (nonatomic) BOOL hidesForSinglePage;			// hide the the indicator if there is only one page. default is NO
 @property (nonatomic) BOOL defersCurrentPageDisplay;	// if set, clicking to a new page won't update the currently displayed page until -updateCurrentPageDisplay is called. default is NO

--- a/SMPageControl.h
+++ b/SMPageControl.h
@@ -38,8 +38,11 @@ typedef NS_ENUM(NSUInteger, SMPageControlTapBehavior) {
 @property (nonatomic, strong) UIImage *pageIndicatorImage				UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIImage *pageIndicatorMaskImage			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
 @property (nonatomic, strong) UIColor *pageIndicatorTintColor			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
+@property (nonatomic, strong) UIColor *pageIndicatorTintStrokeColor			UI_APPEARANCE_SELECTOR; // ignored if pageIndicatorImage is set
+
 @property (nonatomic, strong) UIImage *currentPageIndicatorImage		UI_APPEARANCE_SELECTOR;
 @property (nonatomic, strong) UIColor *currentPageIndicatorTintColor	UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
+@property (nonatomic, strong) UIColor *currentPageIndicatorTintStrokeColor	UI_APPEARANCE_SELECTOR; // ignored if currentPageIndicatorImage is set
 
 @property (nonatomic) BOOL hidesForSinglePage;			// hide the the indicator if there is only one page. default is NO
 @property (nonatomic) BOOL defersCurrentPageDisplay;	// if set, clicking to a new page won't update the currently displayed page until -updateCurrentPageDisplay is called. default is NO

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -78,6 +78,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 {
 	_numberOfPages = 0;
 	_tapBehavior = SMPageControlTapBehaviorStep;
+	
+	_currentPageIndicatorTintStrokeWidth = 1.0f;
+	_pageIndicatorTintStrokeWidth = 1.0f;
     
 	self.backgroundColor = [UIColor clearColor];
 	
@@ -147,6 +150,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	CGFloat yOffset = 0.0f;
 	UIColor *fillColor = nil;
     UIColor *strokeColor = nil;
+	CGFloat strokeWidth = 1.0f;
 	UIImage *image = nil;
 	CGImageRef maskingImage = nil;
 	CGSize maskSize = CGSizeZero;
@@ -157,6 +161,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 		if (i == _displayedPage) {
 			fillColor = _currentPageIndicatorTintColor ? _currentPageIndicatorTintColor : [UIColor whiteColor];
             strokeColor = _currentPageIndicatorTintStrokeColor;
+			strokeWidth = _currentPageIndicatorTintStrokeWidth;
 			image = _currentPageImages[indexNumber];
 			if (nil == image) {
 				image = _currentPageIndicatorImage;
@@ -164,6 +169,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 		} else {
 			fillColor = _pageIndicatorTintColor ? _pageIndicatorTintColor : [[UIColor whiteColor] colorWithAlphaComponent:0.3f];
             strokeColor = _pageIndicatorTintStrokeColor;
+			strokeWidth = _pageIndicatorTintStrokeWidth;
 			image = _pageImages[indexNumber];
 			if (nil == image) {
 				image = _pageIndicatorImage;
@@ -202,7 +208,8 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
             indicatorRect = CGRectMake(centeredXOffset, yOffset, _indicatorDiameter, _indicatorDiameter);
 			CGContextFillEllipseInRect(context, indicatorRect);
             if (strokeColor) {
-                CGContextStrokeEllipseInRect(context, indicatorRect);
+				CGContextSetLineWidth(context, strokeWidth);
+                CGContextStrokeEllipseInRect(context, CGRectInset(indicatorRect, strokeWidth * 0.5f, strokeWidth * 0.5f));
             }
 		}
 		

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -146,6 +146,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 	CGFloat xOffset = left;
 	CGFloat yOffset = 0.0f;
 	UIColor *fillColor = nil;
+    UIColor *strokeColor = nil;
 	UIImage *image = nil;
 	CGImageRef maskingImage = nil;
 	CGSize maskSize = CGSizeZero;
@@ -155,12 +156,14 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 		
 		if (i == _displayedPage) {
 			fillColor = _currentPageIndicatorTintColor ? _currentPageIndicatorTintColor : [UIColor whiteColor];
+            strokeColor = _currentPageIndicatorTintStrokeColor;
 			image = _currentPageImages[indexNumber];
 			if (nil == image) {
 				image = _currentPageIndicatorImage;
 			}
 		} else {
 			fillColor = _pageIndicatorTintColor ? _pageIndicatorTintColor : [[UIColor whiteColor] colorWithAlphaComponent:0.3f];
+            strokeColor = _pageIndicatorTintStrokeColor;
 			image = _pageImages[indexNumber];
 			if (nil == image) {
 				image = _pageIndicatorImage;
@@ -180,7 +183,8 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 			}
 		}
 				
-		[fillColor set];
+		[fillColor setFill];
+        if (strokeColor) [strokeColor setStroke];
 		CGRect indicatorRect;
 		if (image) {
 			yOffset = [self _topOffsetForHeight:image.size.height rect:rect];
@@ -197,6 +201,9 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 			CGFloat centeredXOffset = xOffset + floorf((_measuredIndicatorWidth - _indicatorDiameter) / 2.0f);
             indicatorRect = CGRectMake(centeredXOffset, yOffset, _indicatorDiameter, _indicatorDiameter);
 			CGContextFillEllipseInRect(context, indicatorRect);
+            if (strokeColor) {
+                CGContextStrokeEllipseInRect(context, indicatorRect);
+            }
 		}
 		
         [pageRects addObject:[NSValue valueWithCGRect:indicatorRect]];
@@ -404,6 +411,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 			self.indicatorDiameter = DEFAULT_INDICATOR_WIDTH_LARGE;
 			self.indicatorMargin = DEFAULT_INDICATOR_MARGIN_LARGE;
 			self.pageIndicatorTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.2f];
+            self.pageIndicatorTintStrokeColor = nil;
 			self.minHeight = DEFAULT_MIN_HEIGHT_LARGE;
 			break;
 		case SMPageControlDefaultStyleClassic:
@@ -411,6 +419,7 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 			self.indicatorDiameter = DEFAULT_INDICATOR_WIDTH;
 			self.indicatorMargin = DEFAULT_INDICATOR_MARGIN;
 			self.pageIndicatorTintColor = [[UIColor whiteColor] colorWithAlphaComponent:0.3f];
+            self.pageIndicatorTintStrokeColor = nil;
 			self.minHeight = DEFAULT_MIN_HEIGHT;
 			break;
 	}


### PR DESCRIPTION
Added options to define stroke color (thanks @orsharir) as well as stroke width. Allows the creation of simple hollowed out dots:

``` obj-c
pageControl.indicatorDiameter = 5.0f;
pageControl.pageIndicatorTintColor = [UIColor clearColor];
pageControl.pageIndicatorTintStrokeColor = [UIColor whiteColor];
pageControl.pageIndicatorTintStrokeWidth = 0.5f;
pageControl.currentPageIndicatorTintColor = [UIColor whiteColor];
```
