### PR TITLE
Fixed NSInteger casts and -intrinsicContentSize.

### DIFF
--- a/Example/SMPageControl/SMViewController.m
+++ b/Example/SMPageControl/SMViewController.m
@@ -73,12 +73,12 @@
 
 - (void)pageControl:(id)sender
 {
-	NSLog(@"Current Page (UIPageControl) : %i", self.pageControl.currentPage);
+	NSLog(@"Current Page (UIPageControl) : %li", (long)self.pageControl.currentPage);
 }
 
 - (void)spacePageControl:(SMPageControl *)sender
 {
-	NSLog(@"Current Page (SMPageControl): %i", sender.currentPage);
+	NSLog(@"Current Page (SMPageControl): %li", (long)sender.currentPage);
 }
 
 @end

--- a/SMPageControl.m
+++ b/SMPageControl.m
@@ -378,9 +378,10 @@ static SMPageControlStyleDefaults _defaultStyleForSystemVersion;
 - (CGSize)intrinsicContentSize
 {
 	if (_numberOfPages < 1 || (_numberOfPages < 2 && _hidesForSinglePage)) {
-		return CGSizeMake(UIViewNoIntrinsicMetric, 0.0f);
+		return CGSizeZero;
 	}
-	CGSize intrinsicContentSize = CGSizeMake(UIViewNoIntrinsicMetric, MAX(_measuredIndicatorHeight, _minHeight));
+    CGFloat intrinsicContentWidth = [self sizeForNumberOfPages:self.numberOfPages].width;
+	CGSize intrinsicContentSize = CGSizeMake(intrinsicContentWidth, MAX(_measuredIndicatorHeight, _minHeight));
 	return intrinsicContentSize;
 }
 


### PR DESCRIPTION
- The cast fix gets rid of compiler warnings in the example.
- -intrinsicContentSize fix replaces UIViewNoIntrinsicMetric constant with an actual width.
